### PR TITLE
use service name from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ kamon.newrelic {
 
     # Optional
     # https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api
-    service-name = "Unknown"
 }
 ```
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -6,7 +6,6 @@ kamon.newrelic {
     # A New Relic Insights API Insert Key is required to send trace data to New Relic
     # https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#insert-key-create
     nr-insights-insert-key = "none"
-    service-name = "Unknown"
 }
 
 kamon.modules {

--- a/src/main/scala/kamon/newrelic/NewRelicSpanReporter.scala
+++ b/src/main/scala/kamon/newrelic/NewRelicSpanReporter.scala
@@ -12,10 +12,7 @@ import org.slf4j.LoggerFactory
 import scala.jdk.CollectionConverters._
 
 class NewRelicSpanReporter(spanBatchSenderBuilder: SpanBatchSenderBuilder =
-                           new SimpleSpanBatchSenderBuilder("kamon.newrelic")) extends SpanReporter {
-
-  // TODO figure out how to handle exceptions when the optional config settings don't exist
-  //  com.typesafe.config.ConfigException$Missing: No configuration setting found for key 'service-name'
+                           new SimpleSpanBatchSenderBuilder()) extends SpanReporter {
 
   private val logger = LoggerFactory.getLogger(classOf[NewRelicSpanReporter])
   private var spanBatchSender = spanBatchSenderBuilder.build(Kamon.config())
@@ -24,7 +21,7 @@ class NewRelicSpanReporter(spanBatchSenderBuilder: SpanBatchSenderBuilder =
   private def buildCommonAttributes(config: Config) = {
     new Attributes()
       .put("instrumentation.source", "kamon-agent")
-      .put("service.name", config.getConfig("kamon.newrelic").getString("service-name"))
+      .put("service.name", config.getConfig("kamon.environment").getString("service"))
   }
 
   checkJoinParameter()

--- a/src/main/scala/kamon/newrelic/SpanBatchSenderBuilder.scala
+++ b/src/main/scala/kamon/newrelic/SpanBatchSenderBuilder.scala
@@ -11,7 +11,7 @@ trait SpanBatchSenderBuilder {
   def build(config: Config): SpanBatchSender
 }
 
-class SimpleSpanBatchSenderBuilder(configPath: String) extends SpanBatchSenderBuilder {
+class SimpleSpanBatchSenderBuilder() extends SpanBatchSenderBuilder {
 
   private val logger = LoggerFactory.getLogger(classOf[SpanBatchSenderBuilder])
 
@@ -23,7 +23,7 @@ class SimpleSpanBatchSenderBuilder(configPath: String) extends SpanBatchSenderBu
    */
   override def build(config: Config) = {
     logger.warn("NewRelicSpanReporter buildReporter...")
-    val nrConfig = config.getConfig(configPath)
+    val nrConfig = config.getConfig("kamon.newrelic")
     // TODO maybe some validation around these values?
     val nrInsightsInsertKey = nrConfig.getString("nr-insights-insert-key")
 

--- a/src/test/scala/kamon/newrelic/NewRelicSpanReporterSpec.scala
+++ b/src/test/scala/kamon/newrelic/NewRelicSpanReporterSpec.scala
@@ -38,8 +38,8 @@ class NewRelicSpanReporterSpec extends WordSpec with Matchers {
 
       val reporter = new NewRelicSpanReporter(builder)
       //change the service name attribute and make sure that we reconfigure with it!
-      val configObject: ConfigValue = ConfigValueFactory.fromMap(Map("service-name" -> "cheese-whiz").asJava)
-      val config: Config = Kamon.config().withValue("kamon.newrelic", configObject)
+      val configObject: ConfigValue = ConfigValueFactory.fromMap(Map("service" -> "cheese-whiz").asJava)
+      val config: Config = Kamon.config().withValue("kamon.environment", configObject)
       reporter.reconfigure(config)
 
       val kamonSpan = TestSpanHelper.makeKamonSpan(Client, TestSpanHelper.spanId)
@@ -51,7 +51,7 @@ class NewRelicSpanReporterSpec extends WordSpec with Matchers {
     }
   }
 
-  private def buildExpectedBatch(serviceName: String = "Unknown") = {
+  private def buildExpectedBatch(serviceName: String = "kamon-application") = {
     val expectedAttributes = new Attributes()
       .put("xx", TestSpanHelper.now)
       .put("span.kind", "client")


### PR DESCRIPTION
Since the service name is already specified in the environment, let's use it from there instead of specifying our own.