### PR TITLE
This changes the attributes to use the kamon environment, rather than trying to pull…

### DIFF
--- a/src/main/scala/kamon/newrelic/metrics/NewRelicMetricsReporter.scala
+++ b/src/main/scala/kamon/newrelic/metrics/NewRelicMetricsReporter.scala
@@ -12,6 +12,7 @@ import kamon.Kamon
 import kamon.metric.PeriodSnapshot
 import kamon.module.{MetricReporter, Module, ModuleFactory}
 import kamon.newrelic.AttributeBuddy.buildCommonAttributes
+import kamon.newrelic.LibraryVersion
 import kamon.status.Environment
 import org.slf4j.LoggerFactory
 
@@ -75,6 +76,7 @@ object NewRelicMetricsReporter {
     val nrInsightsInsertKey = nrConfig.getString("nr-insights-insert-key")
     SimpleMetricBatchSender.builder(nrInsightsInsertKey)
       .enableAuditLogging()
+      .secondaryUserAgent("newrelic-kamon-reporter", LibraryVersion.version)
       .build()
   }
 }

--- a/src/main/scala/kamon/newrelic/spans/NewRelicSpanReporter.scala
+++ b/src/main/scala/kamon/newrelic/spans/NewRelicSpanReporter.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright 2020 New Relic Corporation. All rights reserved.
+ *  SPDX-License-Identifier: Apache-2.0
  */
 
 package kamon.newrelic.spans
@@ -10,6 +10,7 @@ import com.typesafe.config.Config
 import kamon.Kamon
 import kamon.module.{Module, ModuleFactory, SpanReporter}
 import kamon.newrelic.AttributeBuddy.buildCommonAttributes
+import kamon.status.Environment
 import kamon.trace.Span
 import org.slf4j.LoggerFactory
 
@@ -20,7 +21,7 @@ class NewRelicSpanReporter(spanBatchSenderBuilder: SpanBatchSenderBuilder =
 
   private val logger = LoggerFactory.getLogger(classOf[NewRelicSpanReporter])
   @volatile private var spanBatchSender = spanBatchSenderBuilder.build(Kamon.config())
-  @volatile private var commonAttributes = buildCommonAttributes(Kamon.config())
+  @volatile private var commonAttributes = buildCommonAttributes(Kamon.environment)
 
   checkJoinParameter()
   logger.info("Started the New Relic Span reporter")
@@ -49,9 +50,14 @@ class NewRelicSpanReporter(spanBatchSenderBuilder: SpanBatchSenderBuilder =
   }
 
   override def reconfigure(newConfig: Config): Unit = {
+    reconfigure(newConfig, Kamon.environment)
+  }
+
+  //exposed for testing
+  def reconfigure(newConfig: Config, environment: Environment): Unit = {
     logger.debug("NewRelicSpanReporter reconfigure...")
     spanBatchSender = spanBatchSenderBuilder.build(newConfig)
-    commonAttributes = buildCommonAttributes(newConfig)
+    commonAttributes = buildCommonAttributes(environment)
     checkJoinParameter()
   }
 

--- a/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
+++ b/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
@@ -1,15 +1,19 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright 2020 New Relic Corporation. All rights reserved.
+ *  SPDX-License-Identifier: Apache-2.0
  */
 
 package kamon.newrelic.metrics
+
+import java.net.InetAddress
 
 import com.newrelic.telemetry.Attributes
 import com.newrelic.telemetry.metrics._
 import com.typesafe.config.{Config, ConfigValue, ConfigValueFactory}
 import kamon.Kamon
 import kamon.metric.{MetricSnapshot, PeriodSnapshot}
+import kamon.status.Environment
+import kamon.tag.TagSet
 import org.mockito.Mockito._
 import org.scalatest.{Matchers, WordSpec}
 
@@ -80,7 +84,7 @@ class NewRelicMetricsReporterSpec extends WordSpec with Matchers {
       val expectedCommonAttributes: Attributes = new Attributes()
         .put("service.name", "kamon-application")
         .put("instrumentation.source", "kamon-agent")
-        .put("host", "auto")
+        .put("host", InetAddress.getLocalHost.getHostName)
         .put("testTag", "testValue")
       val expectedBatch: MetricBatch = new MetricBatch(Seq(count1, count2, gauge, histogramGauge, histogramSummary, timerGauge, timerSummary).asJava, expectedCommonAttributes)
 
@@ -113,7 +117,7 @@ class NewRelicMetricsReporterSpec extends WordSpec with Matchers {
       val sender = mock(classOf[MetricBatchSender])
       val reporter = new NewRelicMetricsReporter(() => sender)
 
-      reporter.reconfigure(config)
+      reporter.reconfigure(Environment("thing", "cheese-whiz", null, null, TagSet.of("testTag", "testThing")))
       reporter.reportPeriodSnapshot(periodSnapshot)
 
       verify(sender).sendBatch(expectedBatch)

--- a/src/test/scala/kamon/newrelic/spans/NewRelicSpanReporterSpec.scala
+++ b/src/test/scala/kamon/newrelic/spans/NewRelicSpanReporterSpec.scala
@@ -1,14 +1,18 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright 2020 New Relic Corporation. All rights reserved.
+ *  SPDX-License-Identifier: Apache-2.0
  */
 
 package kamon.newrelic.spans
+
+import java.net.InetAddress
 
 import com.newrelic.telemetry.Attributes
 import com.newrelic.telemetry.spans.{SpanBatch, SpanBatchSender, Span => NewRelicSpan}
 import com.typesafe.config.{Config, ConfigValue, ConfigValueFactory}
 import kamon.Kamon
+import kamon.status.Environment
+import kamon.tag.TagSet
 import kamon.trace.Span
 import kamon.trace.Span.Kind.Client
 import org.mockito.ArgumentMatchers.any
@@ -46,7 +50,7 @@ class NewRelicSpanReporterSpec extends WordSpec with Matchers {
       val tagDetails = ConfigValueFactory.fromMap(Map("testTag" -> "testThing").asJava)
       val configObject: ConfigValue = ConfigValueFactory.fromMap(Map("service" -> "cheese-whiz", "host" -> "thing", "tags" -> tagDetails).asJava)
       val config: Config = Kamon.config().withValue("kamon.environment", configObject)
-      reporter.reconfigure(config)
+      reporter.reconfigure(config, Environment("thing", "cheese-whiz", null, null, TagSet.of("testTag", "testThing")))
 
       val kamonSpan = TestSpanHelper.makeKamonSpan(Client, TestSpanHelper.spanId)
       val spans: Seq[Span.Finished] = Seq(kamonSpan)
@@ -57,7 +61,7 @@ class NewRelicSpanReporterSpec extends WordSpec with Matchers {
     }
   }
 
-  private def buildExpectedBatch(serviceName: String = "kamon-application", hostName : String = "auto", tagValue: String = "testValue" ) = {
+  private def buildExpectedBatch(serviceName: String = "kamon-application", hostName : String = InetAddress.getLocalHost.getHostName, tagValue: String = "testValue" ) = {
     val expectedAttributes = new Attributes()
       .put("xx", TestSpanHelper.now)
       .put("span.kind", "client")


### PR DESCRIPTION
… it out of the config.

There are also a few bits in here to make a bit more compatible with older scala versions.

resolves #31 