### PR TITLE
Remove the reporting of the percentile countAtRank attribute

### DIFF
--- a/src/main/scala/kamon/newrelic/AttributeBuddy.scala
+++ b/src/main/scala/kamon/newrelic/AttributeBuddy.scala
@@ -7,7 +7,6 @@ package kamon.newrelic
 
 import com.newrelic.telemetry.Attributes
 import com.typesafe.config.{Config, ConfigValue}
-import kamon.Kamon
 import kamon.status.Environment
 import kamon.tag.{Tag, TagSet}
 

--- a/src/main/scala/kamon/newrelic/metrics/NewRelicDistributionMetrics.scala
+++ b/src/main/scala/kamon/newrelic/metrics/NewRelicDistributionMetrics.scala
@@ -50,9 +50,8 @@ object NewRelicDistributionMetrics {
     percentilesToReport
       .map(rank => distValue.percentile(rank))
       .filter(percentileValue => percentileValue != null)
-      .map { percentile =>
+      .map { percentile: Distribution.Percentile =>
         val attributes: Attributes = instrumentBaseAttributes.copy()
-          .put("percentile.countAtRank", percentile.countAtRank)
           .put("percentile", percentile.rank)
         new Gauge(name + ".percentiles", percentile.value, end, attributes)
       }

--- a/src/test/scala/kamon/newrelic/metrics/NewRelicDistributionMetricsSpec.scala
+++ b/src/test/scala/kamon/newrelic/metrics/NewRelicDistributionMetricsSpec.scala
@@ -25,7 +25,7 @@ class NewRelicDistributionMetricsSpec extends WordSpec with Matchers {
         .put("dimension", "information")
         .put("sourceMetricType", "mountain")
       val summary = new Summary("trev.summary", 44, 101.0, 13.0, 17.0, TestMetricHelper.start, TestMetricHelper.end, summaryAttributes)
-      val gaugeAttributes = summaryAttributes.copy().put("percentile.countAtRank", 816L).put("percentile", 90.0d)
+      val gaugeAttributes = summaryAttributes.copy().put("percentile", 90.0d)
       val gauge = new Gauge("trev.percentiles", 2.0, TestMetricHelper.end, gaugeAttributes)
       val expectedMetrics = Seq(gauge, summary)
       val result = NewRelicDistributionMetrics(TestMetricHelper.start, TestMetricHelper.end, distributions, "mountain")

--- a/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
+++ b/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
@@ -63,12 +63,12 @@ class NewRelicMetricsReporterSpec extends WordSpec with Matchers {
   private val gauge: Metric = new Gauge("shirley", 15.6d, TestMetricHelper.end, gaugeAttributes)
 
   private val histogramGauge: Metric = new Gauge("trev.percentiles", 2.0, TestMetricHelper.end,
-    histogramSummaryAttributes.copy().put("percentile.countAtRank", 816L).put("percentile", 90.0d))
+    histogramSummaryAttributes.copy().put("percentile", 90.0d))
   private val histogramSummary: Metric = new Summary("trev.summary", 44, 101.0, 13.0, 17.0,
     TestMetricHelper.start, TestMetricHelper.end, histogramSummaryAttributes)
 
   private val timerGauge: Metric = new Gauge("timer.percentiles", 4.0, TestMetricHelper.end,
-    timerSummaryAttributes.copy().put("percentile.countAtRank", 1632L).put("percentile", 95.0d))
+    timerSummaryAttributes.copy().put("percentile", 95.0d))
   private val timerSummary: Metric = new Summary("timer.summary", 88, 202.0, 26.0, 34.0,
     TestMetricHelper.start, TestMetricHelper.end, timerSummaryAttributes)
 


### PR DESCRIPTION
Since it can vary with every reporting cycle, it would blow out cardinality limits very quickly.