### PR TITLE
rename instrumentation.source to instrumentation.provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Span data can be:
   {
     "common": {
       "attributes": {
-        "instrumentation.source": "kamon-agent",
+        "instrumentation.provider": "kamon-agent",
         "service.name": "Test Service A",
         "host": "host123.test.com"
       }

--- a/src/main/scala/kamon/newrelic/AttributeBuddy.scala
+++ b/src/main/scala/kamon/newrelic/AttributeBuddy.scala
@@ -43,7 +43,7 @@ object AttributeBuddy {
 
   def buildCommonAttributes(environment: Environment): Attributes = {
     val attributes = new Attributes()
-      .put("instrumentation.source", "kamon-agent")
+      .put("instrumentation.provider", "kamon-agent")
       .put("service.name", environment.service)
       .put("host", environment.host)
     AttributeBuddy.addTagsFromTagSets(Seq(environment.tags), attributes)

--- a/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
+++ b/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
@@ -83,7 +83,7 @@ class NewRelicMetricsReporterSpec extends WordSpec with Matchers {
 
       val expectedCommonAttributes: Attributes = new Attributes()
         .put("service.name", "kamon-application")
-        .put("instrumentation.source", "kamon-agent")
+        .put("instrumentation.provider", "kamon-agent")
         .put("host", InetAddress.getLocalHost.getHostName)
         .put("testTag", "testValue")
       val expectedBatch: MetricBatch = new MetricBatch(Seq(count1, count2, gauge, histogramGauge, histogramSummary, timerGauge, timerSummary).asJava, expectedCommonAttributes)
@@ -105,7 +105,7 @@ class NewRelicMetricsReporterSpec extends WordSpec with Matchers {
 
       val expectedCommonAttributes: Attributes = new Attributes()
         .put("service.name", "cheese-whiz")
-        .put("instrumentation.source", "kamon-agent")
+        .put("instrumentation.provider", "kamon-agent")
         .put("testTag", "testThing")
         .put("host", "thing")
       val expectedBatch: MetricBatch = new MetricBatch(Seq(count1, count2, gauge, histogramGauge, histogramSummary).asJava, expectedCommonAttributes)

--- a/src/test/scala/kamon/newrelic/spans/NewRelicSpanReporterSpec.scala
+++ b/src/test/scala/kamon/newrelic/spans/NewRelicSpanReporterSpec.scala
@@ -75,7 +75,7 @@ class NewRelicSpanReporterSpec extends WordSpec with Matchers {
       .parentId(TestSpanHelper.parentId)
       .build()
     val commonAttributes = new Attributes()
-      .put("instrumentation.source", "kamon-agent")
+      .put("instrumentation.provider", "kamon-agent")
       .put("service.name", serviceName)
       .put("host", hostName)
       .put("testTag", tagValue)


### PR DESCRIPTION
This was supposed to be `instrumentation.provider` all along.